### PR TITLE
Add attribute accessor methods when provided attribute value is blank

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,7 @@
 language: ruby
 rvm:
-  - 2.3.0
-  - 2.2.4
-  - 2.0.0-p598
-  - 1.9.3
-  - 1.8.7-head
-  - jruby-head
+  - 2.3.1
+  - 2.2.5
   - ruby-head
   - rbx-3.13
 bundler_args: --without test

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.5.0. set accessor methods when attribute value is blank, instead of ignoring
+
 v0.4.0. add from_json() and register_listener() methods
 
 v0.3.7. don't mix in private methods when Morph is included

--- a/lib/morph.rb
+++ b/lib/morph.rb
@@ -111,7 +111,7 @@ module Chas
   end
 
   def self.argument_provided? args
-    args.size > 0 && !args[0].nil? && !(args[0].is_a?(String) && args[0].strip.size == 0)
+    args.size > 0
   end
 
   def self.convert_to_morph_class_name label
@@ -132,7 +132,7 @@ module Chas
 end
 
 module Morph
-  VERSION = '0.4.1' unless defined? Morph::VERSION
+  VERSION = '0.5.0' unless defined? Morph::VERSION
 
   class << self
     def classes

--- a/spec/lib/morph_spec.rb
+++ b/spec/lib/morph_spec.rb
@@ -29,27 +29,21 @@ describe Morph do
   let(:extended_morph) { extended_morphed_class.new }
 
   describe "when writer method that didn't exist before is called with non-nil value" do
-    before(:all) { initialize_morph }
-    after(:all)  { unload_morph_class }
-
-    let(:quack)     { 'quack' }
-    let(:attribute) { 'noise' }
-    let(:expected_morph_methods_count) { 2 }
+    include_context 'single attribute value set', 'noise', 'quack'
 
     context do
       before do
-        remove_morph_methods
-        @morph.noise = quack
+        @morph.noise = value
       end
 
       it_should_behave_like "class with generated accessor methods added"
 
       it 'should return assigned value when reader method called' do
-        expect(@morph.noise).to eq quack
+        expect(@morph.noise).to eq value
       end
 
       it 'should return hash of attributes when morph_attributes called' do
-        expect(@morph.morph_attributes).to eq({attribute.to_sym => quack})
+        expect(@morph.morph_attributes).to eq({attribute.to_sym => value})
       end
 
       it 'should generate rails model generator script line, with given model name' do
@@ -79,15 +73,9 @@ describe Morph do
   end
 
   describe "when writer method that didn't exist before is called with nil value" do
-    after(:all)  { unload_morph_class }
+    include_context 'single attribute value set', 'noise', nil
 
-    let(:attributes) { ['noise'] }
-    let(:expected_morph_methods_count) { 2 }
-
-    before(:all) do
-      initialize_morph
-      @morph.noise= nil
-    end
+    before { @morph.noise = value }
 
     it_should_behave_like "class with generated accessor methods added"
   end
@@ -187,37 +175,19 @@ describe Morph do
   end
 
   describe "when writer method that didn't exist before is called with blank space attribute value" do
-    after(:all)  { unload_morph_class }
+    include_context 'single attribute value set', 'noise', '   '
 
-    let(:attributes) { [:noise] }
-    let(:expected_morph_methods_count) { 2 }
-
-    before(:all) do
-      initialize_morph
-      @morph.noise = '   '
-    end
+    before { @morph.noise = value }
 
     it_should_behave_like "class with generated accessor methods added"
   end
 
   describe 'when morph method used to set attribute value' do
-    before(:all) { initialize_morph }
-    after(:all)  { unload_morph_class }
+    include_context 'single attribute value set', 'reading', '20 Mar 2008'
 
-    let(:attribute) { 'reading' }
-    let(:value)     { '20 Mar 2008' }
-    let(:expected_morph_methods_count) { 2 }
-
-    before do
-      remove_morph_methods
-      @morph.morph('Reading', value)
-    end
+    before { @morph.morph('Reading', value) }
 
     it_should_behave_like "class with generated accessor methods added"
-
-    it 'should return assigned value when reader method called' do
-      expect(@morph.reading).to eq value
-    end
   end
 
   describe 'when morph method used to set an attribute value hash' do
@@ -226,6 +196,7 @@ describe Morph do
 
     let(:expected_morph_methods_count) { 6 }
     let(:attributes) { [:drink,:sugars,:milk] }
+    let(:value) { 'tea' }
 
     before do
       remove_morph_methods
@@ -268,10 +239,6 @@ describe Morph do
     end
 
     it_should_behave_like "class with generated accessor methods added"
-
-    it 'should return assigned value when reader method called' do
-      @morph.send(@attribute.to_sym) == @age
-    end
   end
   describe "when morph method used to set japanese and latin unicode attribute name with a value" do
     before :all do initialize_morph; end
@@ -291,37 +258,21 @@ describe Morph do
     end
 
     it_should_behave_like "class with generated accessor methods added"
-
-    it 'should return assigned value when reader method called' do
-      @morph.send(@attribute.to_sym) == @age
-    end
   end
 =end
 
   describe 'when morph method used to set blank space attribute value' do
-    after(:all)  { unload_morph_class }
+    include_context 'single attribute value set', 'pizza', '   '
 
-    let(:attributes) { [:pizza] }
-    let(:expected_morph_methods_count) { 2 }
-
-    before(:all) do
-      initialize_morph
-      @morph.morph('Pizza', '   ')
-    end
+    before(:each) { @morph.morph('Pizza', value) }
 
     it_should_behave_like "class with generated accessor methods added"
   end
 
   describe 'when morph method used to set nil attribute value' do
-    after(:all)  { unload_morph_class }
+    include_context 'single attribute value set', 'pizza', nil
 
-    let(:attributes) { [:pizza] }
-    let(:expected_morph_methods_count) { 2 }
-
-    before(:all) do
-      initialize_morph
-      @morph.morph('Pizza', nil)
-    end
+    before { @morph.morph('Pizza', value) }
 
     it_should_behave_like "class with generated accessor methods added"
   end
@@ -344,24 +295,11 @@ describe Morph do
   end
 
   describe "when writer method called matches a class reader method" do
+    include_context 'single attribute value set', 'name', 'Morph'
 
-    before(:all) { initialize_morph }
-    after(:all)  { unload_morph_class }
-
-    let(:attribute) { 'name' }
-    let(:value)     { 'Morph' }
-    let(:expected_morph_methods_count) { 2 }
-
-    before do
-      remove_morph_methods
-      @morph.name = value
-    end
+    before { @morph.name = value }
 
     it_should_behave_like "class with generated accessor methods added"
-
-    it 'should return assigned value when reader method called' do
-      expect(@morph.name).to eq value
-    end
   end
 
 

--- a/spec/lib/morph_spec.rb
+++ b/spec/lib/morph_spec.rb
@@ -81,14 +81,15 @@ describe Morph do
   describe "when writer method that didn't exist before is called with nil value" do
     after(:all)  { unload_morph_class }
 
-    let(:attribute) { 'noise' }
+    let(:attributes) { ['noise'] }
+    let(:expected_morph_methods_count) { 2 }
 
     before(:all) do
       initialize_morph
       @morph.noise= nil
     end
 
-    it_should_behave_like "class without generated accessor methods added"
+    it_should_behave_like "class with generated accessor methods added"
   end
 
   describe "when different writer method called on two different morph classes" do
@@ -188,14 +189,15 @@ describe Morph do
   describe "when writer method that didn't exist before is called with blank space attribute value" do
     after(:all)  { unload_morph_class }
 
-    let(:attribute) { 'noise' }
+    let(:attributes) { [:noise] }
+    let(:expected_morph_methods_count) { 2 }
 
     before(:all) do
       initialize_morph
       @morph.noise = '   '
     end
 
-    it_should_behave_like "class without generated accessor methods added"
+    it_should_behave_like "class with generated accessor methods added"
   end
 
   describe 'when morph method used to set attribute value' do
@@ -299,27 +301,29 @@ describe Morph do
   describe 'when morph method used to set blank space attribute value' do
     after(:all)  { unload_morph_class }
 
-    let(:attribute) { 'pizza' }
+    let(:attributes) { [:pizza] }
+    let(:expected_morph_methods_count) { 2 }
 
     before(:all) do
       initialize_morph
       @morph.morph('Pizza', '   ')
     end
 
-    it_should_behave_like "class without generated accessor methods added"
+    it_should_behave_like "class with generated accessor methods added"
   end
 
   describe 'when morph method used to set nil attribute value' do
     after(:all)  { unload_morph_class }
 
-    let(:attribute) { 'pizza' }
+    let(:attributes) { [:pizza] }
+    let(:expected_morph_methods_count) { 2 }
 
     before(:all) do
       initialize_morph
       @morph.morph('Pizza', nil)
     end
 
-    it_should_behave_like "class without generated accessor methods added"
+    it_should_behave_like "class with generated accessor methods added"
   end
 
 
@@ -695,14 +699,14 @@ xsi_schema_location: xmlgwdev.companieshouse.gov.uk/v1-0/schema/CompanyDetails.x
       expect(councillor.party).to eq 'labour'
       expect(councillor.councillors).to eq 'Councillor for Stretford Ward'
       expect(councillor.councils).to eq 'Trafford Council'
-      expect(councillor.respond_to?(:council_experience)).to be false
+      expect(councillor.respond_to?(:council_experience)).to be true
 
       councillor = councillors.last
       expect(councillor.name).to eq 'Ali Davidson'
       expect(councillor.party).to eq 'labour'
       expect(councillor.councillors).to eq nil_value
       expect(councillor.councils).to eq 'Basildon District Council'
-      expect(councillor.respond_to?(:council_experience)).to be false
+      expect(councillor.respond_to?(:council_experience)).to be true
     end
 
     describe 'tsv (tab separated value)' do

--- a/spec/morph_spec_helper.rb
+++ b/spec/morph_spec_helper.rb
@@ -102,25 +102,3 @@ shared_examples_for "class with generated accessor methods added" do |klass|
 
 end
 
-shared_examples_for "class without generated accessor methods added" do
-
-  it 'should not add reader method to class instance_methods list' do
-    expect(instance_methods).to_not include(attribute)
-  end
-
-  it 'should not add writer method to class instance_methods list' do
-    expect(instance_methods).to_not include("#{attribute}=")
-  end
-
-  it 'should not add reader method to class morph_methods list' do
-    expect(morph_methods).to_not include(attribute)
-  end
-
-  it 'should not add writer method to class morph_methods list' do
-    expect(morph_methods).to_not include("#{attribute}=")
-  end
-
-  it 'should have empty morph_methods list' do
-    expect(morph_methods.size).to eq 0
-  end
-end

--- a/spec/morph_spec_helper.rb
+++ b/spec/morph_spec_helper.rb
@@ -64,7 +64,13 @@ shared_examples_for "class with generated accessor methods added" do |klass|
     klass = morphed_class unless klass
   end
 
-  it 'should add reader method to class instance_methods list' do
+  it 'sets first attribute value correctly' do
+    attribute = nil
+    each_attribute {|a| attribute = a unless attribute}
+    expect(@morph.send(attribute)).to eq value
+  end
+
+  it 'adds reader method to class instance_methods list' do
     if RUBY_VERSION >= "1.9"
       each_attribute { |a| expect(instance_methods(klass)).to include(a.to_s.to_sym) }
     else
@@ -72,7 +78,7 @@ shared_examples_for "class with generated accessor methods added" do |klass|
     end
   end
 
-  it 'should add writer method to class instance_methods list' do
+  it 'adds writer method to class instance_methods list' do
     if RUBY_VERSION >= "1.9"
       each_attribute { |a| expect(instance_methods(klass)).to include("#{a}=".to_sym) }
     else
@@ -80,7 +86,7 @@ shared_examples_for "class with generated accessor methods added" do |klass|
     end
   end
 
-  it 'should add reader method to class morph_methods list' do
+  it 'adds reader method to class morph_methods list' do
     if RUBY_VERSION >= "1.9"
       each_attribute { |a| expect(morph_methods(klass)).to include(a.to_s.to_sym) }
     else
@@ -88,7 +94,7 @@ shared_examples_for "class with generated accessor methods added" do |klass|
     end
   end
 
-  it 'should add writer method to class morph_methods list' do
+  it 'adds writer method to class morph_methods list' do
     if RUBY_VERSION >= "1.9"
       each_attribute { |a| expect(morph_methods(klass)).to include("#{a}=".to_sym) }
     else
@@ -96,9 +102,19 @@ shared_examples_for "class with generated accessor methods added" do |klass|
     end
   end
 
-  it 'should only have generated accessor methods in morph_methods list' do
+  it 'only has generated accessor methods in morph_methods list' do
     expect(morph_methods(klass).size).to eq expected_morph_methods_count
   end
 
 end
 
+shared_context 'single attribute value set' do |field, value|
+  before(:all)  { initialize_morph }
+  after(:all)  { unload_morph_class }
+
+  let(:attribute) { field }
+  let(:expected_morph_methods_count) { 2 }
+  let(:value) { value }
+
+  before { remove_morph_methods }
+end


### PR DESCRIPTION
Create attribute accessor methods and set value when provided attribute value is blank, instead of not creating accessor methods.
