### PR TITLE
Replace Fixnum with Integer to prevent deprecation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
+  - 2.4.0
   - 2.3.1
   - 2.2.5
   - ruby-head
-  - rbx-3.13
 bundler_args: --without test
 script: bundle exec rspec spec

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.5.1. replace Fixnum with Integer to prevent deprecation warning in Ruby 2.4
+
 v0.5.0. set accessor methods when attribute value is blank, instead of ignoring
 
 v0.4.0. add from_json() and register_listener() methods

--- a/lib/morph.rb
+++ b/lib/morph.rb
@@ -303,7 +303,7 @@ module Morph
           value = value.to_time if defined?(XMLRPC::DateTime) && value.is_a?(XMLRPC::DateTime)
 
           case value
-            when String, Date, Time, TrueClass, FalseClass, Fixnum, Float
+            when String, Date, Time, TrueClass, FalseClass, Integer, Float
               object.morph(attribute, value)
             when Array
               attribute = attribute.pluralize

--- a/lib/morph.rb
+++ b/lib/morph.rb
@@ -132,7 +132,7 @@ module Chas
 end
 
 module Morph
-  VERSION = '0.5.0' unless defined? Morph::VERSION
+  VERSION = '0.5.1' unless defined? Morph::VERSION
 
   class << self
     def classes


### PR DESCRIPTION
Prevent Ruby 2.4 deprecation warning by replacing Fixnum with Integer.