### PR TITLE
Drop Ruby < 1.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: ruby
 rvm:
-  - 2.4.0
-  - 2.3.1
-  - 2.2.5
+  - 2.6.2
+  - 2.5.5
+  - 2.4.5
+  - 2.3.8
+  - 2.2.10
   - ruby-head
 bundler_args: --without test
 script: bundle exec rspec spec

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v0.6.0. drop Ruby < 1.9 support, test against Ruby 2.5/2.6, require activesupport >= 4.1.11
+
 v0.5.1. replace Fixnum with Integer to prevent deprecation warning in Ruby 2.4
 
 v0.5.0. set accessor methods when attribute value is blank, instead of ignoring

--- a/Gemfile
+++ b/Gemfile
@@ -6,15 +6,7 @@ end
 
 group :development do
   gem 'rspec'
-end
-
-if RUBY_VERSION < '1.9'
-  gem 'i18n', '0.6.11'
-  gem 'activesupport', '~> 3.2.0'
-  gem 'fastercsv'
-  gem 'rake', '~> 0.9.2.2' # required for travis builds
-  gem 'json'
-else
-  gem 'activesupport'
   gem 'rake'
 end
+
+gem 'activesupport', ">= 4.1.11"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Rob McKinnon
+Copyright (c) 2019 Rob McKinnon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To use Morph:
     require 'morph'
 ```
 
-Tested to work with Ruby 1.8 - 2.3, JRuby 9, and Rubinius 3.
+Tested to work with Ruby 2.2 - 2.6.
 
 ## Morph creating classes `from_json`
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ spec = Gem::Specification.new do |s|
   s.version           = Morph::VERSION
   s.summary           = 'Morph allows you to emerge Ruby class definitions from data or by calling assignment methods.'
   s.author            = 'Rob McKinnon'
-  s.email             = 'rob ~@nospam@~ rubyforge.org'
+  s.email             = 'rob ~@nospam@~ movingflow'
   s.homepage          = 'https://github.com/robmckinnon/morph'
 
   s.has_rdoc          = true
@@ -27,7 +27,7 @@ spec = Gem::Specification.new do |s|
   s.files             = %w(CHANGELOG LICENSE) + Dir.glob('{lib}/**/*')
   s.require_paths     = ['lib']
 
-  s.add_runtime_dependency('activesupport', '>= 2.0.2')
+  s.add_runtime_dependency('activesupport', '>= 4.1.11')
   s.add_development_dependency('rspec')
 end
 


### PR DESCRIPTION
Test against Ruby 2.5, 2.6.

Require activesupport >= 4.1.11.

Bump version number.